### PR TITLE
Updated logging messages to fix issue #14

### DIFF
--- a/src/Steeltoe.Discovery.EurekaBase/DiscoveryClient.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/DiscoveryClient.cs
@@ -317,7 +317,7 @@ namespace Steeltoe.Discovery.Eureka
                     }
                     catch (Exception e)
                     {
-                        _logger?.LogError("Instance_StatusChangedEvent Exception: {0}", e);
+                        _logger?.LogError(e, "Instance_StatusChangedEvent Failed");
                     }
                 }
             }
@@ -364,7 +364,7 @@ namespace Steeltoe.Discovery.Eureka
             catch (Exception e)
             {
                 // Log
-                _logger?.LogError("FetchRegistry failed, Exception: {0}", e);
+                _logger?.LogError(e, "FetchRegistry Failed");
                 return false;
             }
 
@@ -398,12 +398,12 @@ namespace Steeltoe.Discovery.Eureka
             try
             {
                 EurekaHttpResponse resp = await HttpClient.CancelAsync(inst.AppName, inst.InstanceId);
-                _logger?.LogDebug("Unregister {0}/{1} returned: {2}", inst.AppName, inst.InstanceId, resp.StatusCode);
+                _logger?.LogDebug("Unregister {Application}/{Instance} returned: {StatusCode}", inst.AppName, inst.InstanceId, resp.StatusCode);
                 return resp.StatusCode == HttpStatusCode.OK;
             }
             catch (Exception e)
             {
-                _logger?.LogError("Unregister failed, Exception:", e);
+                _logger?.LogError(e, "Unregister Failed");
             }
 
             _logger?.LogDebug("Unregister failed");
@@ -422,7 +422,7 @@ namespace Steeltoe.Discovery.Eureka
             {
                 EurekaHttpResponse resp = await HttpClient.RegisterAsync(inst);
                 var result = resp.StatusCode == HttpStatusCode.NoContent;
-                _logger?.LogDebug("Register {0}/{1} returned: {2}", inst.AppName, inst.InstanceId, resp.StatusCode);
+                _logger?.LogDebug("Register {Application}/{Instance} returned: {StatusCode}", inst.AppName, inst.InstanceId, resp.StatusCode);
                 if (result)
                 {
                     LastGoodRegisterTimestamp = System.DateTime.UtcNow.Ticks;
@@ -432,7 +432,7 @@ namespace Steeltoe.Discovery.Eureka
             }
             catch (Exception e)
             {
-                _logger?.LogError("Register failed, Exception: {0}", e);
+                _logger?.LogError(e, "Register Failed");
             }
 
             _logger?.LogDebug("Register failed");
@@ -450,7 +450,7 @@ namespace Steeltoe.Discovery.Eureka
             try
             {
                 EurekaHttpResponse<InstanceInfo> resp = await HttpClient.SendHeartBeatAsync(inst.AppName, inst.InstanceId, inst, InstanceStatus.UNKNOWN);
-                _logger?.LogDebug("Renew {0}/{1} returned: {2}", inst.AppName, inst.InstanceId, resp.StatusCode);
+                _logger?.LogDebug("Renew {Application}/{Instance} returned: {StatusCode}", inst.AppName, inst.InstanceId, resp.StatusCode);
                 if (resp.StatusCode == HttpStatusCode.NotFound)
                 {
                     return await RegisterAsync();
@@ -466,7 +466,7 @@ namespace Steeltoe.Discovery.Eureka
             }
             catch (Exception e)
             {
-                _logger?.LogError("Renew failed, Exception: {0}", e);
+                _logger?.LogError(e, "Renew Failed");
             }
 
             _logger?.LogDebug("Renew failed");
@@ -489,7 +489,7 @@ namespace Steeltoe.Discovery.Eureka
             }
 
             _logger?.LogDebug(
-                "FetchFullRegistry returned: {0}, {1}",
+                "FetchFullRegistry returned: {StatusCode}, {Response}",
                 resp.StatusCode,
                 (resp.Response != null) ? resp.Response.ToString() : "null");
             if (resp.StatusCode == HttpStatusCode.OK)
@@ -518,7 +518,7 @@ namespace Steeltoe.Discovery.Eureka
             Applications delta = null;
 
             EurekaHttpResponse<Applications> resp = await HttpClient.GetDeltaAsync();
-            _logger?.LogDebug("FetchRegistryDelta returned: {0}", resp.StatusCode);
+            _logger?.LogDebug("FetchRegistryDelta returned: {StatusCode}", resp.StatusCode);
             if (resp.StatusCode == HttpStatusCode.OK)
             {
                 delta = resp.Response;
@@ -536,7 +536,7 @@ namespace Steeltoe.Discovery.Eureka
                 string hashCode = _localRegionApps.ComputeHashCode();
                 if (!hashCode.Equals(delta.AppsHashCode))
                 {
-                    _logger?.LogWarning("FetchRegistryDelta discarding delta, hashcodes mismatch: {0}!={1}", hashCode, delta.AppsHashCode);
+                    _logger?.LogWarning($"FetchRegistryDelta discarding delta, hashcodes mismatch: {hashCode}!={delta.AppsHashCode}");
                     return await FetchFullRegistryAsync();
                 }
                 else
@@ -571,8 +571,8 @@ namespace Steeltoe.Discovery.Eureka
                 catch (Exception e)
                 {
                     _logger?.LogError(
-                        "RefreshInstanceInfo HealthCheck handler exception: {0}, App: {1}, Instance: {2} marked DOWN",
                         e,
+                        "RefreshInstanceInfo HealthCheck handler. App: {Application}, Instance: {Instance} marked DOWN",
                         info.AppName,
                         info.InstanceId);
                     status = InstanceStatus.DOWN;

--- a/src/Steeltoe.Discovery.EurekaBase/EurekaDiscoveryClient.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/EurekaDiscoveryClient.cs
@@ -121,7 +121,7 @@ namespace Steeltoe.Discovery.Eureka
             List<IServiceInstance> instances = new List<IServiceInstance>();
             foreach (InstanceInfo info in infos)
             {
-                _logger?.LogDebug("GetInstances returning: {0}", info.ToString());
+                _logger?.LogDebug($"GetInstances returning: {info}");
                 instances.Add(new EurekaServiceInstance(info));
             }
 

--- a/src/Steeltoe.Discovery.EurekaBase/Transport/EurekaHttpClient.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/Transport/EurekaHttpClient.cs
@@ -88,7 +88,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
 
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
-                    _logger?.LogDebug("RegisterAsync {0}, status: {1}", requestUri.ToString(), response.StatusCode);
+                    _logger?.LogDebug("RegisterAsync {RequestUri}, status: {StatusCode}", requestUri.ToString(), response.StatusCode);
                     EurekaHttpResponse resp = new EurekaHttpResponse(response.StatusCode)
                     {
                         Headers = response.Headers
@@ -104,7 +104,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("RegisterAsync Exception:", e);
+                _logger?.LogError(e, "RegisterAsync Failed");
                 throw;
             }
             finally
@@ -170,7 +170,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
                     }
 
                     _logger?.LogDebug(
-                        "SendHeartbeatAsync {0}, status: {1}, instanceInfo: {2}",
+                        "SendHeartbeatAsync {RequestUri}, status: {StatusCode}, instanceInfo: {Instance}",
                         requestUri.ToString(),
                         response.StatusCode,
                         (infoResp != null) ? infoResp.ToString() : "null");
@@ -183,7 +183,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("SendHeartbeatAsync Exception: {0}", e);
+                _logger?.LogError(e, "SendHeartBeatAsync Failed");
                 throw;
             }
             finally
@@ -254,7 +254,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
                     }
 
                     _logger?.LogDebug(
-                        "GetApplicationAsync {0}, status: {1}, application: {2}",
+                        "GetApplicationAsync {RequestUri}, status: {StatusCode}, application: {Application}",
                         requestUri.ToString(),
                         response.StatusCode,
                         (appResp != null) ? appResp.ToString() : "null");
@@ -267,7 +267,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("GetApplicationAsync Exception: {0}", e);
+                _logger?.LogError(e, "GetApplicationAsync Failed");
                 throw;
             }
             finally
@@ -329,7 +329,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             {
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
-                    _logger?.LogDebug("CancelAsync {0}, status: {1}", requestUri.ToString(), response.StatusCode);
+                    _logger?.LogDebug("CancelAsync {RequestUri}, status: {StatusCode}", requestUri.ToString(), response.StatusCode);
                     EurekaHttpResponse resp = new EurekaHttpResponse(response.StatusCode)
                     {
                         Headers = response.Headers
@@ -339,7 +339,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("CancelAsync Exception: {0}", e);
+                _logger?.LogError(e, "CancelAsync Failed");
                 throw;
             }
             finally
@@ -385,7 +385,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             {
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
-                    _logger?.LogDebug("DeleteStatusOverrideAsync {0}, status: {1}", requestUri.ToString(), response.StatusCode);
+                    _logger?.LogDebug("DeleteStatusOverrideAsync {RequestUri}, status: {StatusCode}", requestUri.ToString(), response.StatusCode);
                     EurekaHttpResponse resp = new EurekaHttpResponse(response.StatusCode)
                     {
                         Headers = response.Headers
@@ -395,7 +395,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("DeleteStatusOverrideAsync Exception: {0}", e);
+                _logger?.LogError(e, "DeleteStatusOverrideAsync Failed");
                 throw;
             }
             finally
@@ -443,7 +443,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             {
                 using (HttpResponseMessage response = await client.SendAsync(request))
                 {
-                    _logger?.LogDebug("StatusUpdateAsync {0}, status: {1}", requestUri.ToString(), response.StatusCode);
+                    _logger?.LogDebug("StatusUpdateAsync {RequestUri}, status: {StatusCode}", requestUri.ToString(), response.StatusCode);
                     EurekaHttpResponse resp = new EurekaHttpResponse(response.StatusCode)
                     {
                         Headers = response.Headers
@@ -453,7 +453,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("StatusUpdateAsync Exception: {0}", e);
+                _logger?.LogError(e, "StatusUpdateAsync Failed");
                 throw;
             }
             finally
@@ -555,7 +555,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
                     }
 
                     _logger?.LogDebug(
-                        "DoGetInstanceAsync {0}, status: {1}, instanceInfo: {2}",
+                        "DoGetInstanceAsync {RequestUri}, status: {StatusCode}, instanceInfo: {Instance}",
                        requestUri.ToString(),
                        response.StatusCode,
                        (infoResp != null) ? infoResp.ToString() : "null");
@@ -568,7 +568,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("DoGetInstanceAsync Exception: {0}", e);
+                _logger?.LogError(e, "DoGetInstanceAsync Failed");
                 throw;
             }
             finally
@@ -616,7 +616,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
                     }
 
                     _logger?.LogDebug(
-                        "DoGetApplicationsAsync {0}, status: {1}, applications: {2}",
+                        "DoGetApplicationsAsync {RequestUri}, status: {StatusCode}, applications: {Application}",
                         requestUri.ToString(),
                         response.StatusCode,
                         (appsResp != null) ? appsResp.ToString() : "null");
@@ -629,7 +629,7 @@ namespace Steeltoe.Discovery.Eureka.Transport
             }
             catch (Exception e)
             {
-                _logger?.LogError("DoGetApplicationsAsync Exception: {0}", e);
+                _logger?.LogError(e, "DoGetApplicationsAsync Failed");
                 throw;
             }
             finally
@@ -654,12 +654,12 @@ namespace Steeltoe.Discovery.Eureka.Transport
             try
             {
                 string json = JsonConvert.SerializeObject(toSerialize);
-                _logger?.LogDebug("GetRequestContent generated JSON: {0}", json);
+                _logger?.LogDebug($"GetRequestContent generated JSON: {json}");
                 return new StringContent(json, Encoding.UTF8, "application/json");
             }
             catch (Exception e)
             {
-                _logger?.LogError("GetRequestContent Exception: {0}", e);
+                _logger?.LogError(e, "GetRequestContent Failed");
             }
 
             return new StringContent(string.Empty, Encoding.UTF8, "application/json");


### PR DESCRIPTION
Should fix #14
 
Updated logging message to use {Application} logging syntax rather than {0} C# syntax.
I also noticed that all the LogError() calls were passing the exception as the second argument; this should be the first one and message should be second. 

`void LogError(this ILogger logger, Exception exception, string message, params object[] args);`