### PR TITLE
Health checks for eureka service, dependency app health checks publis…

### DIFF
--- a/src/Steeltoe.Discovery.EurekaBase/DiscoveryClient.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/DiscoveryClient.cs
@@ -449,6 +449,7 @@ namespace Steeltoe.Discovery.Eureka
 
             try
             {
+                RefreshInstanceInfo();
                 EurekaHttpResponse<InstanceInfo> resp = await HttpClient.SendHeartBeatAsync(inst.AppName, inst.InstanceId, inst, InstanceStatus.UNKNOWN);
                 _logger?.LogDebug("Renew {Application}/{Instance} returned: {StatusCode}", inst.AppName, inst.InstanceId, resp.StatusCode);
                 if (resp.StatusCode == HttpStatusCode.NotFound)

--- a/src/Steeltoe.Discovery.EurekaBase/EurekaApplicationHealthContributor.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/EurekaApplicationHealthContributor.cs
@@ -1,0 +1,62 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
+using Steeltoe.Common.HealthChecks;
+using Steeltoe.Discovery.Eureka.AppInfo;
+using Steeltoe.Discovery.Eureka.Util;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Steeltoe.Discovery.Eureka
+{
+    public class EurekaApplicationHealthContributor : IHealthContributor
+    {
+        private readonly EurekaDiscoveryClient _discoveryClient;
+
+        public EurekaApplicationHealthContributor(string id, EurekaDiscoveryClient discoveryClient)
+        {
+            _discoveryClient = discoveryClient;
+            Id = id;
+        }
+
+        public HealthCheckResult Health()
+        {
+            var serviceInstances = _discoveryClient.GetInstancesByVipAddress(Id, false);
+            var hasHealthyInstances = serviceInstances.Any(x => x.Status == InstanceStatus.UP);
+            var result = new HealthCheckResult();
+            result.Status = hasHealthyInstances ? HealthStatus.UP : HealthStatus.DOWN;
+            result.Details.Add("status", result.Status.ToString());
+            if (result.Status != HealthStatus.UP)
+            {
+                object healthDetails;
+                if (serviceInstances.Any())
+                {
+                    var healthDetailsJson = serviceInstances.First().Metadata["health"];
+                    healthDetails = JsonConvert.DeserializeObject<Dictionary<string, object>>(healthDetailsJson, new DictionaryObjectConverter());
+                }
+                else
+                {
+                    healthDetails = "No running instances";
+                }
+
+                result.Details.Add("details", healthDetails);
+            }
+
+            return result;
+        }
+
+        public string Id { get; }
+    }
+}

--- a/src/Steeltoe.Discovery.EurekaBase/EurekaDiscoveryClient.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/EurekaDiscoveryClient.cs
@@ -61,13 +61,14 @@ namespace Steeltoe.Discovery.Eureka
             IOptionsMonitor<EurekaInstanceOptions> instConfig,
             EurekaApplicationInfoManager appInfoManager,
             IEurekaHttpClient httpClient = null,
-            ILoggerFactory logFactory = null)
+            ILoggerFactory logFactory = null,
+            IHealthCheckHandler healthCheckHandler = null)
             : base(appInfoManager, logFactory)
         {
             _thisInstance = new ThisServiceInstance(instConfig);
             _configOptions = clientConfig;
             _httpClient = httpClient;
-
+            HealthCheckHandler = healthCheckHandler;
             if (_httpClient == null)
             {
                 _httpClient = new EurekaHttpClientInternal(clientConfig, logFactory);

--- a/src/Steeltoe.Discovery.EurekaBase/EurekaHealthContributor.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/EurekaHealthContributor.cs
@@ -1,0 +1,52 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Steeltoe.Common.HealthChecks;
+using System;
+using System.Linq;
+
+namespace Steeltoe.Discovery.Eureka
+{
+    public class EurekaHealthContributor : IHealthContributor
+    {
+        private readonly EurekaDiscoveryClient _discoveryClient;
+        private readonly EurekaApplicationInfoManager _appInfoManager;
+
+        public EurekaHealthContributor(EurekaDiscoveryClient discoveryClient, EurekaApplicationInfoManager appInfoManager)
+        {
+            _discoveryClient = discoveryClient;
+            _appInfoManager = appInfoManager;
+        }
+
+        public HealthCheckResult Health()
+        {
+            var result = new HealthCheckResult();
+            var lastEurekaTimestamp = new[]
+            {
+                _discoveryClient.LastGoodRegistryFetchTimestamp,
+                _discoveryClient.LastGoodHeartbeatTimestamp,
+                _discoveryClient.LastGoodRegisterTimestamp,
+                _discoveryClient.LastGoodDeltaRegistryFetchTimestamp,
+                _discoveryClient.LastGoodFullRegistryFetchTimestamp,
+            }.Max();
+            var isHealthy = new DateTime(lastEurekaTimestamp)
+                                .AddSeconds(_appInfoManager.InstanceInfo.LeaseInfo.RenewalIntervalInSecs + 5) > DateTime.UtcNow;
+            result.Status = isHealthy ? HealthStatus.UP : HealthStatus.DOWN;
+            result.Details.Add("status", result.Status.ToString());
+            return result;
+        }
+
+        public string Id => "Eureka";
+    }
+}

--- a/src/Steeltoe.Discovery.EurekaBase/HealthContributorHandler.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/HealthContributorHandler.cs
@@ -1,0 +1,89 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
+using Steeltoe.Common.HealthChecks;
+using Steeltoe.Discovery.Eureka.AppInfo;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Steeltoe.Discovery.Eureka
+{
+    public class HealthContributorHandler : IHealthCheckHandler
+    {
+        private EurekaApplicationInfoManager _appManager;
+        private IList<IHealthContributor> _contributors;
+        private Lazy<IEnumerable<IHealthContributor>> _contributorFactory;
+
+        public HealthContributorHandler(EurekaApplicationInfoManager appManager, Lazy<IEnumerable<IHealthContributor>> contributors)
+        {
+            _appManager = appManager;
+            _contributorFactory = contributors;
+        }
+
+        public InstanceStatus GetStatus(InstanceStatus currentStatus)
+        {
+            if (!_contributorFactory.IsValueCreated)
+            {
+                _contributors = _contributorFactory.Value.ToList();
+            }
+
+            if (!_contributors.Any())
+            {
+                return currentStatus;
+            }
+
+            var result = InstanceStatus.UP;
+            var details = new Dictionary<string, object>();
+            foreach (var contributor in _contributors)
+            {
+                InstanceStatus newStatus;
+                try
+                {
+                    var health = contributor.Health();
+                    details[contributor.Id] = health.Details;
+                    switch (health.Status)
+                    {
+                        case HealthStatus.UP:
+                            newStatus = InstanceStatus.UP;
+                            break;
+                        case HealthStatus.DOWN:
+                            newStatus = InstanceStatus.DOWN;
+                            break;
+                        case HealthStatus.OUT_OF_SERVICE:
+                            newStatus = InstanceStatus.OUT_OF_SERVICE;
+                            break;
+                        default:
+                            newStatus = InstanceStatus.UNKNOWN;
+                            break;
+                    }
+                }
+                catch (Exception e)
+                {
+                    newStatus = InstanceStatus.DOWN;
+                    details[contributor.Id] = new Dictionary<string, object> { { "error", e.ToString() } };
+                }
+
+                if (newStatus > result)
+                {
+                    result = newStatus;
+                    _appManager.InstanceInfo.Metadata["health"] = JsonConvert.SerializeObject(details);
+                }
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Steeltoe.Discovery.EurekaBase/Util/DictionaryObjectConverter.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/Util/DictionaryObjectConverter.cs
@@ -1,0 +1,50 @@
+// Copyright 2017 the original author or authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Collections.Generic;
+
+namespace Steeltoe.Discovery.Eureka.Util
+{
+    public class DictionaryObjectConverter : CustomCreationConverter<IDictionary<string, object>>
+    {
+        public override IDictionary<string, object> Create(Type objectType)
+        {
+            return new Dictionary<string, object>();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            // in addition to handling IDictionary<string, object>
+            // we want to handle the deserialization of dict value
+            // which is of type object
+            return objectType == typeof(object) || base.CanConvert(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.StartObject
+                || reader.TokenType == JsonToken.Null)
+            {
+                return base.ReadJson(reader, objectType, existingValue, serializer);
+            }
+
+            // if the next token is not an object
+            // then fall back on standard deserializer (strings, numbers etc.)
+            return serializer.Deserialize(reader);
+        }
+    }
+}


### PR DESCRIPTION
- Introduces actuator health check for eureka service, auto registered when consuming eureka
- Ability to declare dependent services in eureka and setup health checks for them
- Automatically mark instances as unhealthy in eureka when internal health checks fail
- Publish results of internal health checks as eureka metadata