### PR TITLE
Fix NullReferenceException w/ApplicationUris in UpdateWithDefaultsForRoute

### DIFF
--- a/src/Steeltoe.Discovery.EurekaBase/EurekaPostConfigurer.cs
+++ b/src/Steeltoe.Discovery.EurekaBase/EurekaPostConfigurer.cs
@@ -160,7 +160,11 @@ namespace Steeltoe.Discovery.Eureka
             UpdateWithDefaults(si, instOptions);
             instOptions.NonSecurePort = DEFAULT_NONSECUREPORT;
             instOptions.SecurePort = DEFAULT_SECUREPORT;
-            instOptions.InstanceId = si.ApplicationInfo.ApplicationUris[0] + ":" + si.ApplicationInfo.InstanceId;
+
+            if (si.ApplicationInfo.ApplicationUris?.Length > 0)
+            {
+                instOptions.InstanceId = si.ApplicationInfo.ApplicationUris[0] + ":" + si.ApplicationInfo.InstanceId;
+            }
         }
 
         private static void UpdateWithDefaults(EurekaServiceInfo si, EurekaInstanceOptions instOptions)


### PR DESCRIPTION
Addresses issue #58. Sample exception follows. The function `UpdateWithDefaults` has a null and length check around `ApplicationInfo.ApplicationUris` but `UpdateWithDefaultsForRoute` does not.

<pre>
2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR Unhandled Exception: System.NullReferenceException: Object reference not set to an instance of an object.
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Steeltoe.Discovery.Eureka.EurekaPostConfigurer.UpdateWithDefaultsForRoute(EurekaServiceInfo si, EurekaInstanceOptions instOptions)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.Options.OptionsFactory`1.Create(String name)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at System.Lazy`1.ViaFactory(LazyThreadSafetyMode mode)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at System.Lazy`1.ExecutionAndPublication(LazyHelper executionAndPublication, Boolean useDefaultConstructor)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at System.Lazy`1.CreateValue()
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Steeltoe.Discovery.Eureka.EurekaApplicationInfoManager..ctor(IOptionsMonitor`1 instConfig, ILoggerFactory logFactory)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR --- End of stack trace from previous location where exception was thrown ---
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, ServiceProviderEngineScope scope)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScoped(ScopedCallSite scopedCallSite, ServiceProviderEngineScope scope)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitConstructor(ConstructorCallSite constructorCallSite, ServiceProviderEngineScope scope)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScoped(ScopedCallSite scopedCallSite, ServiceProviderEngineScope scope)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetService[T](IServiceProvider provider)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Steeltoe.Discovery.Client.DiscoveryServiceCollectionExtensions.<>c.b__12_0(IServiceProvider p)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceLookup.CallSiteRuntimeResolver.VisitScoped(ScopedCallSite scopedCallSite, ServiceProviderEngineScope scope)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService(IServiceProvider provider, Type serviceType)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at Microsoft.Extensions.DependencyInjection.ServiceProviderServiceExtensions.GetRequiredService[T](IServiceProvider provider)
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at RiverFlowProcessor.Startup.UseDiscoveryClient() in C:\Source\Tools\river-flow-processor\consumer\Startup.cs:line 71
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at RiverFlowProcessor.Startup.Configure() in C:\Source\Tools\river-flow-processor\consumer\Startup.cs:line 45
   2019-03-20T20:56:31.52-0700 [APP/PROC/WEB/0] ERR    at RiverFlowProcessor.Program.Main(String[] args) in C:\Source\Tools\river-flow-processor\consumer\Program.cs:line 23
</pre>